### PR TITLE
More robust version selection

### DIFF
--- a/_static/ver_dropdown.js
+++ b/_static/ver_dropdown.js
@@ -1,0 +1,3 @@
+window.addEventListener('DOMContentLoaded', function() {
+    document.getElementById("ver-dropdown").style.display = "inline";
+});

--- a/_static/ver_dropdown.js
+++ b/_static/ver_dropdown.js
@@ -1,3 +1,10 @@
-window.addEventListener('DOMContentLoaded', function() {
-    document.getElementById("ver-dropdown").style.display = "inline";
+window.addEventListener("DOMContentLoaded", function() {
+    window.ver_dropdown = document.getElementById("ver-dropdown");
+    window.sel_index = window.ver_dropdown.selectedIndex;
+    window.ver_dropdown.style.display = "inline";
 });
+
+function dropdown_navigate(dest) {
+    window.ver_dropdown.selectedIndex = window.sel_index;
+    window.location = dest;
+};

--- a/_templates/searchbox.html
+++ b/_templates/searchbox.html
@@ -1,15 +1,14 @@
-{% for version_option in versions %}
-  {% if version_option|string() == version|string() %}
-    <span class="sidebar-curr-version">{{ version_option }}</span>
-  {% elif currentvariation is defined %}
-    <a class="sidebar-version-link" href="{{ pathto('../' ~ version_option ~ '/' ~ currentvariation[0]|string() ~ '/' ~ pagename ~ file_suffix, 1) }}">{{ version_option }}</a>
-  {% endif %}
-
-  {% if not loop.last %}
-    <span class="sidebar-sep">|</span>
-  {% endif %}
-{% endfor %}
-
+<span>Version</span>
+{% if currentvariation is defined %}
+  <select id="ver-dropdown" style="display: none;" onchange="window.location = '{{ pathto('../' ~ '\' + this.options[this.selectedIndex].value + \'' ~ '/' ~ currentvariation[0]|string() ~ '/' ~ pagename ~ file_suffix, 1) }}'">
+    {% for version_option in versions %}
+      <option{% if version_option == version %} selected{% endif %}>{{ version_option }}</option>
+    {% endfor %}
+  </select>
+  <noscript><span>{{ version }}</span></noscript>
+{% else %}
+  <span>{{ version }}</span>
+{% endif %}
 <br />
 
 {% for variation in variations %}

--- a/_templates/searchbox.html
+++ b/_templates/searchbox.html
@@ -1,6 +1,6 @@
 <span>Version</span>
 {% if currentvariation is defined %}
-  <select id="ver-dropdown" style="display: none;" onchange="window.location = '{{ pathto('../' ~ '\' + this.options[this.selectedIndex].value + \'' ~ '/' ~ currentvariation[0]|string() ~ '/' ~ pagename ~ file_suffix, 1) }}'">
+  <select id="ver-dropdown" style="display: none;" onchange="dropdown_navigate('{{ pathto('../' ~ '\' + this.options[this.selectedIndex].value + \'' ~ '/' ~ currentvariation[0]|string() ~ '/' ~ pagename ~ file_suffix, 1) }}')">
     {% for version_option in versions %}
       <option{% if version_option == version %} selected{% endif %}>{{ version_option }}</option>
     {% endfor %}

--- a/conf.py
+++ b/conf.py
@@ -121,6 +121,7 @@ html_theme_options = {
 # "<project> v<release> documentation".
 html_title = "Panda3D Manual"
 html_logo = "_static/logo.png"
+html_js_files = ['ver_dropdown.js']
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None
@@ -148,6 +149,7 @@ html_context = {
     'github_repo': 'panda3d-docs',
     'github_version': version,
     'conf_py_path': '/',
+    'version': version,
     'versions': versions,
 }
 


### PR DESCRIPTION
Used an HTML `<select>` element to make version selection a bit more flexible. Only shows itself if javascript is enabled.