### PR TITLE
distribution: Document nsis installer for bdist_apps

### DIFF
--- a/distribution/packaging-binaries.rst
+++ b/distribution/packaging-binaries.rst
@@ -33,3 +33,6 @@ bztar
    A bzip2-compressed tar archive
 xztar
    An xz-compressed tar archive
+nsis
+   An `NSIS-based <https://nsis.sourceforge.io/Main_Page>`_ Windows installer (valid only for Windows targets).
+   Requires that ``makensis`` is available on the host.


### PR DESCRIPTION
This brings the documentation for the `nsis` installer to the same level as the other installers.