### PR TITLE
Geom-related corrections

### DIFF
--- a/programming/internal-structures/geometry-storage/geomvertexdata.rst
+++ b/programming/internal-structures/geometry-storage/geomvertexdata.rst
@@ -41,10 +41,10 @@ then up to you to write a :ref:`vertex shader <shader-basics>` that
 understands what to do with the data in the column.
 
 It is possible to break up a GeomVertexData into more than one array. A
-GeomVertexArray is table of vertex data that is stored in one contiguous block
-of memory. Typically, each GeomVertexData consists of just one array; but it
-is also possible to distribute the data so that some columns are stored in one
-array, while other columns are stored in another array:
+GeomVertexArrayData is a table of vertex data that is stored in one contiguous
+block of memory. Typically, each GeomVertexData consists of just one array; but
+it is also possible to distribute the data so that some columns are stored in
+one array, while other columns are stored in another array:
 
 == ========= ========
 \  vertex    texcoord

--- a/programming/internal-structures/other-manipulation/more-about-reader-writer-rewriter.rst
+++ b/programming/internal-structures/other-manipulation/more-about-reader-writer-rewriter.rst
@@ -36,20 +36,21 @@ The following methods are available to read and write data in a column:
 
 ==================== ====================================================================
 **GeomVertexReader** **GeomVertexWriter**
-x = getData1f()      setData1f(x)addData1f(x)
-v2 = getData2f()     setData2f(x, y)setData2f(v2)addData2f(x, y)addData2f(v2)
-v3 = getData3f()     setData3f(x, y, z)setData3f(v3)addData3f(x, y, z)addData3f(v3)
-v4 = getData4f()     setData4f(x, y, z, w)setData4f(v4)addData4f(x, y, z, w)addData4f(v4)
-x = getData1i()      setData1i(x)addData1i(x)
-\                    setData2i(x, y)addData2i(x, y)
-\                    setData3i(x, y, z)addData3i(x, y, z)
-\                    setData4i(x, y, z, w)addData4i(x, y, z, w)
+x = getData1()      setData1(x) addData1(x)
+v2 = getData2()     setData2(x, y) setData2 (v2) addData2(x, y) addData2(v2)
+v3 = getData3()     setData3(x, y, z) setData3(v3) addData3(x, y, z) addData3(v3)
+v4 = getData4()     setData4(x, y, z, w) setData4(v4) addData4(x, y, z, w) addData4(v4)
+x = getData1i()      setData1i(x) addData1i(x)
+\                    setData2i(x, y) addData2i(x, y)
+\                    setData3i(x, y, z) addData3i(x, y, z)
+\                    setData4i(x, y, z, w) addData4i(x, y, z, w)
 ==================== ====================================================================
 
 Each of the getData family of functions supported by GeomVertexReader returns
 the value of the data in the current column, converted to the requested type.
-The 'f' suffix indicates a floating-point value, while 'i' indicates an integer
-value; the digit indicates the number of components you expect to receive.
+The 'i' suffix indicates an integer value, while the lack of this suffix
+indicates a floating-point value; the digit indicates the number of components
+you expect to receive.
 
 For instance, getData2() always returns a VBase2, regardless of the type of data
 actually stored in the column. If the column contains a 2-component value such

--- a/programming/internal-structures/other-manipulation/more-about-reader-writer-rewriter.rst
+++ b/programming/internal-structures/other-manipulation/more-about-reader-writer-rewriter.rst
@@ -34,17 +34,22 @@ each time you need to access it.
 
 The following methods are available to read and write data in a column:
 
-==================== ====================================================================
+==================== ===================== ============= ===================== ============
 **GeomVertexReader** **GeomVertexWriter**
-x = getData1()       setData1(x) addData1(x)
-v2 = getData2()      setData2(x, y) setData2 (v2) addData2(x, y) addData2(v2)
-v3 = getData3()      setData3(x, y, z) setData3(v3) addData3(x, y, z) addData3(v3)
-v4 = getData4()      setData4(x, y, z, w) setData4(v4) addData4(x, y, z, w) addData4(v4)
-x = getData1i()      setData1i(x) addData1i(x)
-\                    setData2i(x, y) addData2i(x, y)
-\                    setData3i(x, y, z) addData3i(x, y, z)
-\                    setData4i(x, y, z, w) addData4i(x, y, z, w)
-==================== ====================================================================
+-------------------- ----------------------------------------------------------------------
+x = getData1()       setData1(x)                         addData1(x)
+-------------------- ----------------------------------- ----------------------------------
+v2 = getData2()      setData2(x, y)        setData2(v2)  addData2(x, y)        addData2(v2)
+v3 = getData3()      setData3(x, y, z)     setData3(v3)  addData3(x, y, z)     addData3(v3)
+v4 = getData4()      setData4(x, y, z, w)  setData4(v4)  addData4(x, y, z, w)  addData4(v4)
+x = getData1i()      setData1i(x)                        addData1i(x)
+-------------------- ----------------------------------- ----------------------------------
+\                    setData2i(x, y)                     addData2i(x, y)
+-------------------- ----------------------------------- ----------------------------------
+\                    setData3i(x, y, z)                  addData3i(x, y, z)
+-------------------- ----------------------------------- ----------------------------------
+\                    setData4i(x, y, z, w)               addData4i(x, y, z, w)
+==================== =================================== ==================================
 
 Each of the getData family of functions supported by GeomVertexReader returns
 the value of the data in the current column, converted to the requested type.

--- a/programming/internal-structures/other-manipulation/more-about-reader-writer-rewriter.rst
+++ b/programming/internal-structures/other-manipulation/more-about-reader-writer-rewriter.rst
@@ -36,10 +36,10 @@ The following methods are available to read and write data in a column:
 
 ==================== ====================================================================
 **GeomVertexReader** **GeomVertexWriter**
-x = getData1()      setData1(x) addData1(x)
-v2 = getData2()     setData2(x, y) setData2 (v2) addData2(x, y) addData2(v2)
-v3 = getData3()     setData3(x, y, z) setData3(v3) addData3(x, y, z) addData3(v3)
-v4 = getData4()     setData4(x, y, z, w) setData4(v4) addData4(x, y, z, w) addData4(v4)
+x = getData1()       setData1(x) addData1(x)
+v2 = getData2()      setData2(x, y) setData2 (v2) addData2(x, y) addData2(v2)
+v3 = getData3()      setData3(x, y, z) setData3(v3) addData3(x, y, z) addData3(v3)
+v4 = getData4()      setData4(x, y, z, w) setData4(v4) addData4(x, y, z, w) addData4(v4)
 x = getData1i()      setData1i(x) addData1i(x)
 \                    setData2i(x, y) addData2i(x, y)
 \                    setData3i(x, y, z) addData3i(x, y, z)

--- a/programming/internal-structures/procedural-generation/predefined-vertex-formats.rst
+++ b/programming/internal-structures/procedural-generation/predefined-vertex-formats.rst
@@ -34,9 +34,9 @@ v3n3cpt2   ✓                    ✓                                           
 .. only:: python
 
    The predefined formats are accessable through the API using, for example,
-   ``GeomVertexFormat.get_v3v3()``.
+   ``GeomVertexFormat.get_v3n3()``.
 
 .. only:: cpp
 
    The predefined formats are accessable through the API using, for example,
-   ``GeomVertexFormat::get_v3v3()``.
+   ``GeomVertexFormat::get_v3n3()``.


### PR DESCRIPTION
Hi,

There are some mistakes that I came across in the chapter `Advanced operations with internal structures`.

1. In `programming/internal-structures/geometry-storage/geomvertexdata.rst`, there is mention of a `GeomVertexArray` class, which to my knowledge doesn't exist. What is meant is probably `GeomVertexArrayData`.
2. In `programming/internal-structures/procedural-generation/predefined-vertex-formats.rst`, code refers to a non-existent `get_v3v3` method. It is likely that the intended method name was `get_v3n3`.
3. Some references to `getDataxf`, `setDataxf` and `addDataxf` still remain in `programming/internal-structures/other-manipulation/more-about-reader-writer-rewriter.rst`.
Apart from removing the 'f' suffixes, I also took the liberty of sprucing up the layout of the table listing the methods, because the names of those in the GeomVertexWriter column don't even have any space between them currently, which looks quite messy.

Hopefully these changes meet with your approval.