### PR TITLE
Fix mistake in description of interpolation combine mode

### DIFF
--- a/programming/texturing/texture-combine-modes.rst
+++ b/programming/texturing/texture-combine-modes.rst
@@ -107,9 +107,9 @@ In this mode, source1/operand1 is subtracted from source0/operand0.
       ts->set_combine_rgb(TextureStage::CM_interpolate,
                           source0, operand0, source1, operand1, source2, operand2);
 
-This is the only mode that uses three sources. The value of source2/operand2
+This is the only mode that uses three sources. The color value of source2/operand2
 is used to select between source0/operand0 and source1/operand1. When source2
-is 0, source0 is selected, and when source2 is 1, source1 is selected. When
+is 0, source1 is selected, and when source2 is 1, source0 is selected. When
 source2 is between 0 and 1, the color is smoothly blended between source0 and
 source1.
 


### PR DESCRIPTION
Hi,

There seems to be an error in the description of the interpolation combine mode. Specifically, it states that when the color value of source2 is 0, source0 is selected, and when source2 is 1, source1 is selected. Upon testing it seems the opposite is true.

The following code sample procedurally creates a texture containing a white circle on a black background and uses it for the interpolation of a red texture associated with a first texture stage (its sort value is set to 0 and its `saved_result` attribute is set to True) and a green texture, associated with a second texture stage (whose sort is set to 1). This interpolation texture is then associated with a third stage (sort set to 2), using the red texture as source0 (`CS_last_saved_result`) and the green one as source1 (`CS_previous`).

```python
from panda3d.core import *
from direct.showbase.ShowBase import ShowBase


class MyApp(ShowBase):

    def __init__(self):

        ShowBase.__init__(self)

        cm = CardMaker("card")
        cm.set_frame(-1., 1., -1., 1.)
        card = self.render.attach_new_node(cm.generate())

        ts_red = TextureStage("red")
        ts_red.sort = 0
        ts_red.saved_result = True
        ts_green = TextureStage("green")
        ts_green.sort = 1
        ts_green.mode = TextureStage.M_replace
        ts_interp = TextureStage("interpolation")
        ts_interp.sort = 2
        ts_interp.set_combine_rgb(
            TextureStage.CM_interpolate,
            TextureStage.CS_last_saved_result, TextureStage.CO_src_color,
            TextureStage.CS_previous, TextureStage.CO_src_color,
            TextureStage.CS_texture, TextureStage.CO_src_color
        )

        img = PNMImage(1, 1)
        img.fill(1., 0., 0.)
        tex = Texture("red")
        tex.load(img)
        card.set_texture(ts_red, tex)
        img = PNMImage(1, 1)
        img.fill(0., 1., 0.)
        tex = Texture("green")
        tex.load(img)
        card.set_texture(ts_green, tex)
        img = PNMImage(128, 128)
        img.render_spot((1., 1., 1., 1.), (0., 0., 0., 1.), .5, .5)
        tex_interp = Texture("interpolation")
        tex_interp.load(img)
        # display the interpolation result on a card to the right
        card.set_texture(ts_interp, tex_interp)
        card.set_pos(1.5, 10., 0.)

        # display the interpolation texture itself on a card to the left
        card2 = self.render.attach_new_node(cm.generate())
        card2.set_texture(tex_interp)
        card2.set_pos(-1.5, 10., 0.)


app = MyApp()
app.run()
```

![interpolation combine mode](https://user-images.githubusercontent.com/16452534/99152798-50fa3900-26a4-11eb-8b3a-7dc464488615.png)

As you can see in the screenshot at the right, the circle becomes red, while its background turns green. Unless I'm missing something, that doesn't correspond to the current description.

Apart from switching the names of the sources, I've also replaced `The value of source2/operand2` with `The color value of source2/operand2`, since "value" here might be confused with the `CS_texture`, `CO_src_color` etc. values.