### PR TITLE
Create collision-shapes.rst

### DIFF
--- a/programming/physics/bullet/collision-shapes.rst
+++ b/programming/physics/bullet/collision-shapes.rst
@@ -399,6 +399,9 @@ while the GeoMipTerrain uses the lower left corner as its origin. However,
 this can be easily corrected by positioning the GeoMipTerrain with an offset
 relative to the static rigid body node.
 
+If you are using ShaderTerrainMesh, then you need to use Texture object as a height map. 
+This will ensure that the shape of the physical body corresponds to the visible geometry.
+
 .. only:: python
 
    .. code-block:: python


### PR DESCRIPTION
Added a mention of about Texture parameter for the shape of `BulletHeightfieldShape`. If a `ShaderTerrainMesh` is used.