### PR TITLE
Fix Direct- and DistributedObject mixup

### DIFF
--- a/programming/networking/distributed/ai-created-objects.rst
+++ b/programming/networking/distributed/ai-created-objects.rst
@@ -5,7 +5,7 @@ AI-side Created Objects
 
 Similar to the client-side created objects, AI server-side created objects will
 be created and managed on the AI server. The difference is that the classes
-with the AI suffix will be used to create the DirectObject. The respective
+with the AI suffix will be used to create the DistributedObject. The respective
 class without the AI suffix will be created on clients that stated
 with the AI appending will usually be used for creation and hence the AI
 functionality of those nodes can be accessed. Those objects will also be
@@ -21,8 +21,8 @@ An example for creating an AI object directly on the AI server follows.
 
 For a client to know when such an object has been manifested locally, the
 distributed object class (without the AI postfix) can overwrite the
-:meth:`~direct.distributed.DirectObject.DirectObject.announceGenerate()` method
-of :class:`.DirectObject`. This method is called whenever the object has been
+:meth:`~direct.distributed.DistributedObject.announceGenerate()` method
+of :class:`~direct.distributed.DistributedObject`. This method is called whenever the object has been
 created and is ready for further processing on the client. In this method, you
 can for example send the :term:`doId` with a custom event or simply store some
 information in the client repository to later ease the access to those objects.


### PR DESCRIPTION
Changed DirectObject to DistributedObject since there is no DirectObject in the distributed module neither has it an announceGenerate method.

Note: I'm not sure about the class reference whether it should be
:class:`~direct.distributed.DistributedObject`
or
:class:`.DistributedObject`