### PR TITLE
Correct linker path for GNU Linux

### DIFF
--- a/introduction/running-your-program.rst
+++ b/introduction/running-your-program.rst
@@ -173,7 +173,7 @@ Running your Program
       g++ filename.o -o filename -L{panda3dlibs} -lp3framework -lpanda -lpandafx -lpandaexpress -lp3dtoolconfig -lp3dtool -lp3direct
 
    As above, change `{panda3dlibs}` to point to the Panda3D libraries. On Linux
-   this will be ``/usr/lib/panda3d`` or ``/usr/lib/x86_64-gnu-linux/panda3d``,
+   this will be ``/usr/lib/panda3d`` or ``/usr/lib/x86_64-linux-gnu/panda3d``,
    whereas on macOS it will be ``/Library/Developer/Panda3D/lib`` or
    ``/Developer/Panda3D/lib``, depending on your exact version of Panda3D.
 


### PR DESCRIPTION
The path in this did not work on my machine, as it is different from the path used in the .deb files.