### PR TITLE
Fix way of accessing enum value of GraphicsPipe

### DIFF
--- a/programming/render-to-texture/low-level-render-to-texture.rst
+++ b/programming/render-to-texture/low-level-render-to-texture.rst
@@ -158,7 +158,7 @@ is :meth:`~.GraphicsEngine.make_output()` on the :class:`.GraphicsEngine` class.
       win_prop.set_size(512, 512);
 
       // Don't open a window - force it to be an offscreen buffer.
-      int flags = GraphicsPipe.BF_refuse_window;
+      int flags = GraphicsPipe::BF_refuse_window;
 
       GraphicsEngine *engine = GraphicsEngine::get_global_ptr();
       engine->make_output(pipe, "My Buffer", -100, fb_prop, win_prop, flags, win->get_gsg(), win);


### PR DESCRIPTION
Changed dot to double colon when accessing BF_refuse_window from GraphicsPipe class