### PR TITLE
Remove all mentions of dropped Miles sound engine

### DIFF
--- a/introduction/features.rst
+++ b/introduction/features.rst
@@ -97,7 +97,6 @@ Several options for adding sounds to your game:
 
 -  Support for the OpenAL audio engine
 -  Support for the FMOD audio engine
--  Support for the Miles audio engine
 
 |clear|
 

--- a/programming/audio/index.rst
+++ b/programming/audio/index.rst
@@ -6,7 +6,7 @@ Sound
 Sound System Options
 --------------------
 
-To play audio in your game, Panda3D can offer you the following three choices
+To play audio in your game, Panda3D can offer you the following two choices
 of audio libraries:
 
 -  `OpenAL <https://www.openal.org/>`__ is a well-known and popular open-source
@@ -19,10 +19,6 @@ of audio libraries:
    license. Non-commercial use of FMOD is free of charge. (For more
    information on this, visit the
    `FMOD Licenses <https://www.fmod.com/index.php/sales>`__ page.)
--  `Miles <http://www.radgametools.com/miles.htm>`__ is a sound system that is
-   not included in the downloadable binaries of Panda3D. In order to use this
-   you will need to purchase Miles and compile Panda3D from scratch using the
-   ppremake system
 
 If these choices are not enough for you, then you can try other sound
 libraries.
@@ -32,9 +28,9 @@ Setting the Sound System
 
 To configure Panda3D to use a specific sound system, you will need to change
 your :ref:`Config.prc <configuring-panda3d>` configuration. You should look up
-the variable ``audio-library-name`` and change the value to one of
-``p3openal_audio``, ``p3fmod_audio``, or ``miles_audio``. (The names of the
-libraries may differ with the way Panda3D was built.)
+the variable ``audio-library-name`` and change the value to either
+``p3openal_audio`` or ``p3fmod_audio``. (The names of the libraries may differ
+with the way Panda3D was built.)
 
 Extra Notes
 -----------

--- a/programming/audio/manipulating-sounds.rst
+++ b/programming/audio/manipulating-sounds.rst
@@ -67,7 +67,7 @@ Notes on Looping Sounds Seamlessly
 Looping a sound seamlessly should be as simple as loading the sound, then
 calling :meth:`~.AudioSound.set_loop()` and :meth:`~.AudioSound.play()`.
 However, occasionally Panda users have had difficulty getting sounds to loop
-seamlessly. The problems have been traced to three(!) different causes:
+seamlessly. The problems have been traced to two(!) different causes:
 
 #. Some MP3 encoders contain a bug where they add blank space at the end of the
    sound. This causes a skip during looping. Try using a wav instead.
@@ -75,9 +75,6 @@ seamlessly. The problems have been traced to three(!) different causes:
    intervals depend on Panda's Thread to restart the sound, and if the CPU is
    is busy, there's a skip. This is not a seamless method, in general. Use
    :meth:`~.AudioSound.set_loop()` instead.
-#. There is a bug in Miles sound system, which requires a workaround in Panda3D.
-   At one time, the workaround was causing problems with FMOD, until we devised
-   a new workaround. This bug no longer exists, you can ignore it.
 
 So the easiest way to get a reliable looping sound is to use wav files, and to
 use :meth:`~.AudioSound.set_loop()`, not sound intervals. Of course, when it

--- a/programming/configuration/configuring-panda3d.rst
+++ b/programming/configuration/configuring-panda3d.rst
@@ -69,8 +69,6 @@ audio-library-name     p3openal_audio   p3openal_audio     Loads the appropriate
 
                        p3fmod_audio
 
-                       p3miles_audio
-
                        null
 want-directtools       true             true               Enables directtools, a suite of interactive object/camera manipulation tools
 


### PR DESCRIPTION
Miles support was dropped in https://github.com/panda3d/panda3d/commit/1a03d997b237e081f3a195aed11031113a055125 on the 1.11 branch, we shouldn't advertise Miles support anymore.