### PR TITLE
BillboardEffect: Update parameter name case

### DIFF
--- a/programming/render-effects/billboard.rst
+++ b/programming/render-effects/billboard.rst
@@ -95,11 +95,12 @@ yourself:
 .. code-block:: python
 
    myEffect = BillboardEffect.make(
-       upVector=vec3,
-       eyeRelative=bool,
-       axialRotate=bool,
+       up_vector=vec3,
+       eye_relative=bool,
+       axial_rotate=bool,
        offset=float,
-       lookAt=nodepath,
-       lookAtPoint=point3
+       look_at=nodepath,
+       look_at_point=point3,
+       fixed_depth=bool
    )
    myNodePath.node().setEffect(myEffect)


### PR DESCRIPTION
My pull request updates formal parameter names and adds in a missing argument to BillboardEffect.make().

A code snippet on [this](https://docs.panda3d.org/1.10/python/programming/render-effects/billboard) page of the manual is using outdated parameter naming conventions. You can reference the API documentation here: https://docs.panda3d.org/1.10/python/reference/panda3d.core.BillboardEffect#panda3d.core.BillboardEffect.make

If one were to use these args as-is, they would run into a TypeError exception:

```
myBillboard = BillboardEffect.make(
    upVector = Vec3(0,0,1),
    eyeRelative = True,
    axialRotate = False,
    offset = 0.0,
    lookAt = base.cam2d,
    lookAtPoint = Point3(0,0,0)
)
```
causes
`TypeError: make() missing required argument 'up_vector' (pos 1)`