### PR TITLE
mention changing window properties in the manual

### DIFF
--- a/programming/rendering-process/changing-windows.rst
+++ b/programming/rendering-process/changing-windows.rst
@@ -1,0 +1,19 @@
+.. _changing-windows:
+
+Changing Windows
+============================
+
+The ``WindowProperties`` class can be used to alter the behavior of existing windows. If "base" is your showbase instance, change properties of your window like this:
+        
+.. only:: python
+
+   .. code-block:: python
+        from panda3d.core import WindowProperties
+        # ...
+        wp = WindowProperties()
+        wp.setSize(1920),1080)
+        wp.setFullscreen(True)
+        wp.setTitle("My Awesome Game")
+        base.win.requestProperties(wp)
+
+The API for lists ``WindowProperties`` some other functions for common operations, so if you are doing this, it is worth browsing what is available.

--- a/programming/rendering-process/index.rst
+++ b/programming/rendering-process/index.rst
@@ -26,6 +26,7 @@ everything is connected together.
    introducing-graphics-classes
    graphics-pipe
    creating-windows-and-buffers
+   changing-windows
    display-regions
    creating-mouse-watchers
    clearing-display-regions


### PR DESCRIPTION
I wanted to change some window properties and noticed it wasn't mentioned in the manual how to do this, so I took this forum post and turned into a small manual note.

https://discourse.panda3d.org/t/how-do-i-get-a-fullscreen/394/14

I hope the toc works, I didn't try it locally.

It's also missing the c++ part.