### PR TITLE
added dark mode plugin, reference to background

### DIFF
--- a/_static/panda.css
+++ b/_static/panda.css
@@ -111,3 +111,9 @@ body, .wy-body-for-nav {
     border-top: inherit;
     padding: inherit;
 }
+
+@media (prefers-color-scheme: dark) {
+    body, .wy-body-for-nav {
+        background: url("https://www.panda3d.org/wp-content/themes/panda3d/assets/img/elements/background_inverted.jpg") #f9f9f9;
+    }
+}

--- a/conf.py
+++ b/conf.py
@@ -53,6 +53,7 @@ extensions = [
     'sphinx.ext.inheritance_diagram',
     'sphinx.ext.viewcode',
     'sphinx.ext.intersphinx',
+    "sphinx_rtd_dark_mode",
 ]
 
 if build_api_reference:


### PR DESCRIPTION
Just adding the plugin worked like a charm like a charm locally, the exception being only the reference to the background picture, which I also changed in the css. 

So this one has to be merged first, otherwise the link in the css points to nothing.

https://github.com/panda3d/panda3d-web/pull/26