### PR TITLE
C++ Examples: Start with delta-time-only approach, before sub-step approach

### DIFF
--- a/programming/physics/bullet/hello-world.rst
+++ b/programming/physics/bullet/hello-world.rst
@@ -81,7 +81,7 @@ value to the ``do_physics()`` method.
       AsyncTask::DoneStatus update_scene(GenericAsyncTask* task, void* data) {
           // Get dt (from Python example) and apply to do_physics(float, int, int);
           ClockObject *co = ClockObject::get_global_clock();
-          physics_world->do_physics(co->get_dt(), 10, 1.0 / 180.0);
+          physics_world->do_physics(co->get_dt());
 
           return AsyncTask::DS_cont;
       }


### PR DESCRIPTION
In the text of this page, the reader is first introduced to the simple usage of "doPhysics"/"do_physics" with only a delta-time, and later introduced to the use of the sub-step parameters.

And on the Python side, the examples reflect this: the first example of the use of "doPhysics" employs only the delta-time, while the second demonstrates sub-stepping.

However, on the C++ side, the examples _only_ showed the use "do_physics" with sub-steps.

While a close reading of the text might inform the reader that "do_physics" can be used without sub-stepping, and that sub-stepping can have performance impact, I fear that it would be quite easy for a reader to miss that and primarily see the examples.

Hence I'm proposing a change that brings the C++ examples in line with the Python examples, by changing the first example that demonstrates "do_physics" to use only the delta-time.