### PR TITLE
Update flock.rst

### DIFF
--- a/programming/pandai/steering-behaviors/flock.rst
+++ b/programming/pandai/steering-behaviors/flock.rst
@@ -157,7 +157,7 @@ The full working code in Panda3D :
            self.AIworld = AIWorld(render)
 
            #Flock functions
-           self.MyFlock = Flock(1, 270, 10, 2, 4, 0.2)
+           self.MyFlock = Flock(1, 270, 10, 2, 4, 1)
            self.AIworld.addFlock(self.MyFlock)
            self.AIworld.flockOn(1)
 


### PR DESCRIPTION
Fix parameter for Flock class instantiation

If floating point values should be possible for Flock, this may be a bug in the Flock class itself, but the documentation also states integer values as samples for different flock behaviors.